### PR TITLE
Check all classes, not just those that match the file name

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
 Metrics/MethodLength:
   Max: 20

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,7 +29,6 @@ require 'danger_plugin'
 # it comes with an extra function `.string` which will
 # strip all ANSI colours from the string.
 
-# rubocop:disable Lint/NestedMethodDefinition
 def testing_ui
   @output = StringIO.new
   def @output.winsize
@@ -42,7 +41,6 @@ def testing_ui
   end
   cork
 end
-# rubocop:enable Lint/NestedMethodDefinition
 
 # Example environment (ENV) that would come from
 # running a PR on TravisCI


### PR DESCRIPTION
This fixes a bug where having both the interface and impl of a class in the same file would skip coverage check for the impl. 