### PR TITLE
Register FileNameKt class for top-level Kotlin function files

### DIFF
--- a/lib/jacoco/gem_version.rb
+++ b/lib/jacoco/gem_version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Jacoco
-  VERSION = '0.1.16'
+  VERSION = '0.1.17'
 end

--- a/lib/jacoco/plugin.rb
+++ b/lib/jacoco/plugin.rb
@@ -133,6 +133,12 @@ module Danger
 
       file_content = File.read(file)
 
+      # Kotlin compiles top-level functions (e.g. @Composable funs) into a `<FileNameKt>` class.
+      # Always register it — the SAX parser skips it silently if it's absent from the XML.
+      parts = package_path.split('/')
+      kt_class_path = (parts[0..-2] + ["#{parts[-1]}Kt"]).join('/')
+      class_to_file_path_hash[kt_class_path] = file
+
       # Look for class and interface declarations in the file
       # Regex catches class/interface/object declarations with modifiers and generics
       regex = /\b(?:(?:data|sealed|abstract|open|internal|private|protected|public|inline)\s+)*

--- a/spec/fixtures/output_g.xml
+++ b/spec/fixtures/output_g.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.0//EN"
+        "report.dtd">
+<report name="test_report">
+  <sessioninfo id="test-id" start="1480057517395" dump="1480057526412"/>
+  <package name="com/example">
+    <class name="com/example/TopLevelFunctionsKt">
+      <counter type="INSTRUCTION" missed="5" covered="15"/>
+      <counter type="LINE" missed="1" covered="4"/>
+      <counter type="COMPLEXITY" missed="1" covered="3"/>
+      <counter type="METHOD" missed="1" covered="3"/>
+      <counter type="CLASS" missed="0" covered="1"/>
+    </class>
+    <sourcefile name="TopLevelFunctions.kt">
+      <counter type="INSTRUCTION" missed="5" covered="15"/>
+      <counter type="LINE" missed="1" covered="4"/>
+      <counter type="COMPLEXITY" missed="1" covered="3"/>
+      <counter type="METHOD" missed="1" covered="3"/>
+      <counter type="CLASS" missed="0" covered="1"/>
+    </sourcefile>
+    <counter type="INSTRUCTION" missed="5" covered="15"/>
+    <counter type="BRANCH" missed="0" covered="0"/>
+    <counter type="LINE" missed="1" covered="4"/>
+    <counter type="COMPLEXITY" missed="1" covered="3"/>
+    <counter type="METHOD" missed="1" covered="3"/>
+    <counter type="CLASS" missed="0" covered="1"/>
+  </package>
+  <counter type="INSTRUCTION" missed="5" covered="15"/>
+  <counter type="BRANCH" missed="0" covered="0"/>
+  <counter type="LINE" missed="1" covered="4"/>
+  <counter type="COMPLEXITY" missed="1" covered="3"/>
+  <counter type="METHOD" missed="1" covered="3"/>
+  <counter type="CLASS" missed="0" covered="1"/>
+</report>

--- a/spec/jacoco_spec.rb
+++ b/spec/jacoco_spec.rb
@@ -385,6 +385,38 @@ module Danger
         end
       end
 
+      it 'detects top-level Kotlin functions file via the generated Kt-suffixed class' do
+        path_g = "#{File.dirname(__FILE__)}/fixtures/output_g.xml"
+
+        kotlin_file_path = 'src/kotlin/com/example/TopLevelFunctions.kt'
+        kotlin_file_content = <<~KOTLIN
+          package com.example
+
+          @Composable
+          fun FirstComposable() {}
+
+          @Composable
+          fun SecondComposable() {}
+        KOTLIN
+
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with(kotlin_file_path).and_return(true)
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with(kotlin_file_path).and_return(kotlin_file_content)
+
+        @my_plugin.files_to_check = [kotlin_file_path]
+        @my_plugin.minimum_project_coverage_percentage = 0
+        @my_plugin.minimum_class_coverage_percentage = 80
+        @my_plugin.minimum_composable_class_coverage_percentage = 80
+
+        class_file_hash = @my_plugin.classes(%r{/kotlin/})
+        expect(class_file_hash.keys).to include('com/example/TopLevelFunctionsKt')
+
+        @my_plugin.report path_g
+
+        expect(@dangerfile.status_report[:markdowns][0].message).to include('| `com/example/TopLevelFunctionsKt` | 75% | 80% | :warning: |')
+      end
+
       it 'test with kotlin multiples classes in same file' do
         path_a = "#{File.dirname(__FILE__)}/fixtures/output_a.xml"
 


### PR DESCRIPTION
## Summary

- Fixes a silent gap: Kotlin files containing only top-level functions (e.g. `@Composable` funs with no enclosing class) compile to a `<FileNameKt>` synthetic class that the SAX parser never found, so the file was skipped entirely when `fail_no_coverage_data_found` is `false`
- In `add_kotlin_declarations`, unconditionally registers the `Kt`-suffixed path as an additional candidate for every `.kt` file — safe for class-based files since the SAX parser silently skips keys absent from the XML
- Bumps version to `0.1.17`

No visual change — this is a Ruby gem; no UI files are touched.

## Problem detail

`CodeCoverageDangerfile` derives the lookup key from the file path:
```
com/example/ICFinishMyCartV4LoadingComposable
```
But Kotlin emits:
```
com/example/ICFinishMyCartV4LoadingComposableKt
```
No match → file silently skipped, never shown in the coverage table.

## Verification

Full spec suite: 30/30 green locally, including new spec `detects top-level Kotlin functions file via the generated Kt-suffixed class` with fixture `output_g.xml`.

## Test plan
- [ ] `bundle exec rake spec` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)